### PR TITLE
Improved website UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5440,23 +5440,23 @@
       "integrity": "sha512-7CanEvJx74EnvjHu1X8gf93KieyxvFLnqOXAH/ddjWD4RrUZYqdg3pykrQ/7t6SLI7DTsp4tfQXEfzeK5t6oAw=="
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },
@@ -7861,9 +7861,9 @@
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
     },
     "immer": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.9.tgz",
-      "integrity": "sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -11543,9 +11543,9 @@
       }
     },
     "open": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.3.0.tgz",
-      "integrity": "sha512-mgLwQIx2F/ye9SmbrUkurZCnkoXyXyu9EbHtJZrICjVAJfyMArdHp3KkixGdZx1ZHFPNIwl0DDM1dFFqXbTLZw==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "requires": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
@@ -13319,9 +13319,9 @@
       }
     },
     "react-dev-utils": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.1.tgz",
-      "integrity": "sha512-rlgpCupaW6qQqvu0hvv2FDv40QG427fjghV56XyPcP5aKtOAPzNAhQ7bHqk1YdS2vpW1W7aSV3JobedxuPlBAA==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",
+      "integrity": "sha512-dx0LvIGHcOPtKbeiSUM4jqpBl3TcY7CDjZdfOIcKeznE7BWr9dg0iPG90G5yfVQ+p/rGNMXdbfStvzQZEVEi4A==",
       "requires": {
         "@babel/code-frame": "7.10.4",
         "address": "1.1.2",
@@ -13336,13 +13336,13 @@
         "global-modules": "2.0.0",
         "globby": "11.0.1",
         "gzip-size": "5.1.1",
-        "immer": "7.0.9",
+        "immer": "8.0.1",
         "is-root": "2.1.0",
         "loader-utils": "2.0.0",
         "open": "^7.0.2",
         "pkg-up": "3.1.0",
         "prompts": "2.4.0",
-        "react-error-overlay": "^6.0.8",
+        "react-error-overlay": "^6.0.9",
         "recursive-readdir": "2.2.2",
         "shell-quote": "1.7.2",
         "strip-ansi": "6.0.0",
@@ -13474,9 +13474,9 @@
       }
     },
     "react-error-overlay": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.8.tgz",
-      "integrity": "sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw=="
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
     "react-gtm-module": {
       "version": "2.0.11",

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -149,3 +149,7 @@
 		flex-direction: column;
 	}
 }
+
+html {
+	scroll-behavior: smooth;
+}

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -127,7 +127,7 @@ const Header = ({
 												Music v{musicVanced?.version}
 											</Link>
 										</li>
-										<li title="Latest Vanced version">
+										<li title="Features">
 											{/* <Link to="#features" onClick={closeMenu}>
 												Features
 											</Link> */}
@@ -140,11 +140,12 @@ const Header = ({
 												offset={-70}
 												duration={500}
 												style={{ cursor: "pointer" }}
+												onClick={closeMenu}
 											>
 												Features
 											</LinkScroll>
 										</li>
-										<li title="Latest Vanced version">
+										<li title="Vanced Guide">
 											<a
 												href="https://play.google.com/store/apps/details?id=com.vanced.faq"
 												target="_blank"

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -117,14 +117,9 @@ const Header = ({
 											navPosition && `header-nav-${navPosition}`,
 										)}
 									>
-										<li title="Latest Vanced version">
-											<Link to="/changelogs" onClick={closeMenu}>
-												Vanced v{ytVanced?.version}
-											</Link>
-										</li>
-										<li title="Latest Music version">
-											<Link to="/changelogs" onClick={closeMenu}>
-												Music v{musicVanced?.version}
+										<li title="Changelogs" onClick={closeMenu}>
+											<Link to="/changelogs">
+												Changelogs
 											</Link>
 										</li>
 										<li title="Features">
@@ -132,20 +127,9 @@ const Header = ({
 												Features
 											</Link> */}
 
-											<LinkScroll
-												activeClass="active"
-												to="features"
-												spy={true}
-												smooth={true}
-												offset={-70}
-												duration={500}
-												style={{ cursor: "pointer" }}
-											>
-												<Link to="/">
-													Features
-												</Link>
-											</LinkScroll>
-											
+											<Link to="features" onClick={closeMenu}>
+												Features
+											</Link>
 											
 										</li>
 										<li title="Vanced Guide">

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -140,10 +140,13 @@ const Header = ({
 												offset={-70}
 												duration={500}
 												style={{ cursor: "pointer" }}
-												onClick={closeMenu}
 											>
-												Features
+												<Link to="/">
+													Features
+												</Link>
 											</LinkScroll>
+											
+											
 										</li>
 										<li title="Vanced Guide">
 											<a

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -123,14 +123,7 @@ const Header = ({
 											</Link>
 										</li>
 										<li title="Features">
-											{/* <Link to="#features" onClick={closeMenu}>
-												Features
-											</Link> */}
-
-											<Link to="features" onClick={closeMenu}>
-												Features
-											</Link>
-											
+											<a href="/#features">Features</a>
 										</li>
 										<li title="Vanced Guide">
 											<a

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -122,7 +122,7 @@ const Header = ({
 												Vanced v{ytVanced?.version}
 											</Link>
 										</li>
-										<li title="Latest Vanced version">
+										<li title="Latest Music version">
 											<Link to="/changelogs" onClick={closeMenu}>
 												Music v{musicVanced?.version}
 											</Link>


### PR DESCRIPTION
This PR replaces useless Vanced and Music buttons in the header with one "Changelogs" button (see screenshot below). They're useless because both of them redirect to the same `/changelogs` page, which causes some confusion (doesn't even use `/changelogs#vanced` or `/changelogs#music`)

![image](https://user-images.githubusercontent.com/48173186/110940831-f53d7500-8350-11eb-8cee-31e9625736bd.png)

Also, the "Features" button now scrolls to the features content on the home page regardless of what page the user is on.
Hovering on buttons should now provide correct ContentDescription, instead of always saying "Latest Vanced version"
